### PR TITLE
Allow restricting mirrored namespaces

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -30,6 +30,13 @@
 			"description": "When performing a search against the mirrored site, the maximum number of results to fetch",
 			"descriptionmsg": "wikimirror-config-searchmaxresults",
 			"public": true
+		},
+		"WikiMirrorNamespaces": {
+			"value": [ 0 ],
+			"path": false,
+			"description": "Namespaces to mirror, leave empty for all. Note that NS_MEDIAWIKI, NS_FILE, NS_PROJECT, and NS_PROJECT_TALK are never mirrored, and neither are user config pages.",
+			"descriptionmsg": "wikimirror-config-namespaces",
+			"public": true
 		}
 	},
 	"Hooks": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -18,6 +18,7 @@
 	"wikimirror-config-assignknownusers": "When forking pages, whether or not imported revisions will be assigned to local users should their username match",
 	"wikimirror-config-remote": "Interwiki prefix of the remote wiki",
 	"wikimirror-config-searchmaxresults": "When performing a search against the mirrored site, the maximum number of results to fetch",
+	"wikimirror-config-namespaces": "Namespaces to mirror, leave empty for all. Note that NS_MEDIAWIKI, NS_FILE, NS_PROJECT, and NS_PROJECT_TALK are never mirrored, and neither are user config pages.",
 	"wikimirror-delete-success": "The mirrored page \"$1\" has been deleted and may now be created locally. See $2 for a record of recent deletions.",
 	"wikimirror-desc": "Mirror and fork remote wiki articles",
 	"wikimirror-extensionname": "WikiMirror",
@@ -35,7 +36,9 @@
 	"wikimirror-no-edit": "You may not edit a mirrored page; it must be forked first.",
 	"wikimirror-no-mirror": "Unable to mirror $1. It may not exist on the remote wiki or may be a sensitive page.",
 	"wikimirror-nofork-text": "The specified page cannot be forked. It may already exist locally or it may not exist remotely.",
+	"wikimirror-nofork-text-namespace": "The specified page cannot be forked, since it is not in a mirrored namespace.",
 	"wikimirror-nofork-title": "Cannot fork",
 	"wikimirror-nomirror-text": "The specified page cannot be mirrored. It must have been previously forked and subsequently deleted.",
+	"wikimirror-nomirror-text-namespace": "The specified page cannot be mirrored, since it is not in a mirrored namespace.",
 	"wikimirror-nomirror-title": "Cannot mirror"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -18,6 +18,7 @@
 	"wikimirror-config-assignknownusers": "{{optional}} Description of the configuration variable $wgWikiMirrorAssignKnownUsers. This message is not exposed to users.",
 	"wikimirror-config-remote": "{{optional}} Description of the configuration variable $wgWikiMirrorRemote. This message is not exposed to users.",
 	"wikimirror-config-searchmaxresults": "{{optional}} Description of the configuration variable $wgWikiMirrorSearchMaxResults. This message is not exposed to users.",
+	"wikimirror-config-namespaces": "{{optional}} Description of the configuration variable $wgWikiMirrorNamespaces. This message is not exposed to users.",
 	"wikimirror-delete-success": "Success message displayed when a page is forked without importing any revisions.",
 	"wikimirror-desc": "{{desc|name=WikiMirror|url=https://www.mediawiki.org/wiki/Extension:WikiMirror}}",
 	"wikimirror-extensionname": "{{name}}",
@@ -35,7 +36,9 @@
 	"wikimirror-no-edit": "Message displayed to users when they click View Source to view the wikitext of a mirrored page.",
 	"wikimirror-no-mirror": "{{optional}} Error message added to server logs when an error is encountered. This message is not exposed to users. $1 is the name of the page.",
 	"wikimirror-nofork-text": "Error message displayed when the page cannot be forked.",
+	"wikimirror-nofork-text-namespace": "Error message displayed when the page cannot be forked because of the namespace.",
 	"wikimirror-nofork-title": "Header displayed when the page cannot be forked.",
 	"wikimirror-nomirror-text": "Error message displayed when the page cannot be mirrored.",
+	"wikimirror-nomirror-text-namespace": "Error message displayed when the page cannot be mirrored because of the namespace.",
 	"wikimirror-nomirror-title": "Header displayed when the page cannot be mirrored."
 }

--- a/includes/Fork/SpecialFork.php
+++ b/includes/Fork/SpecialFork.php
@@ -101,6 +101,10 @@ class SpecialFork extends UnlistedSpecialPage {
 		// check if this title is currently being mirrored;
 		// if not we can't fork it
 		if ( !$this->mirror->canMirror( $this->title ) ) {
+			// Have a more helpful message for pages in the wrong namespace
+			if ( !$this->mirror->inMirroredNamespace( $this->title ) ) {
+				throw new ErrorPageError( 'wikimirror-nofork-title', 'wikimirror-nofork-text-namespace' );
+			}
 			throw new ErrorPageError( 'wikimirror-nofork-title', 'wikimirror-nofork-text' );
 		}
 

--- a/includes/Fork/SpecialMirror.php
+++ b/includes/Fork/SpecialMirror.php
@@ -66,6 +66,10 @@ class SpecialMirror extends UnlistedSpecialPage {
 		// check if this title is currently forked and deleted
 		// if either is false, we cannot re-mirror it
 		if ( !$this->mirror->isForked( $this->title ) || $this->title->exists() ) {
+			// Have a more helpful message for pages in the wrong namespace
+			if ( !$this->mirror->inMirroredNamespace( $this->title ) ) {
+				throw new ErrorPageError( 'wikimirror-nomirror-title', 'wikimirror-nomirror-text-namespace' );
+			}
 			throw new ErrorPageError( 'wikimirror-nomirror-title', 'wikimirror-nomirror-text' );
 		}
 


### PR DESCRIPTION
Add a new configuration option, `$wgWikiMirrorNamespaces`, that holds an array of the namespaces to mirror - if empty, all namespaces are allowed (except for those with existing checks to prevent them: virtual namespaces, NS_MEDIAWIKI, NS_FILE, NS_PROJECT, and NS_PROJECT_TALK). This new configuration defaults to just mirror the main namespace.

SEL-2228