### PR TITLE
MirrorPageRecord: stop relying on the `remote_redirect` table

### DIFF
--- a/includes/Mirror/Mirror.php
+++ b/includes/Mirror/Mirror.php
@@ -320,7 +320,6 @@ class Mirror {
 		$row = $dbr->newSelectQueryBuilder()
 			->select( '*' )
 			->from( 'remote_page' )
-			->leftJoin( 'remote_redirect', null, 'rp_id = rr_from' )
 			->where( [
 				'rp_namespace' => $namespace,
 				'rp_title' => $dbKey

--- a/includes/Mirror/MirrorPageRecord.php
+++ b/includes/Mirror/MirrorPageRecord.php
@@ -14,8 +14,9 @@ use WikiMirror\API\PageInfoResponse;
 
 class MirrorPageRecord extends PageIdentityValue implements ExistingPageRecord {
 	/**
-	 * Fields that must be present in the constructor.
-	 * Various rr_* fields are all optional since they might be null.
+	 * Fields that must be present in the constructor. Only the fields from
+	 * remote_page are used, remote_redirect usage was dropped so that the
+	 * remote_page table won't need to have the correct page ids.
 	 */
 	public const REQUIRED_FIELDS = [
 		'rp_id',
@@ -60,7 +61,7 @@ class MirrorPageRecord extends PageIdentityValue implements ExistingPageRecord {
 	 * @inheritDoc
 	 */
 	public function isRedirect() {
-		return isset( $this->row->rr_from );
+		return $this->getPageInfo()->redirect !== null;
 	}
 
 	/**


### PR DESCRIPTION
Rather than determining if a mirrored page is a redirect based on whether it has a row in the `remote_redirect` table, use a (cached) API call to check. While this sacrifices a bit of performance, it will allow decoupling mirrored pages from their page ids on the remote wiki.

SEL-2228